### PR TITLE
Voting + bike joining 

### DIFF
--- a/internal/common/objects/BaseBiker.go
+++ b/internal/common/objects/BaseBiker.go
@@ -24,20 +24,29 @@ type ResourceAllocationParams struct {
 type IBaseBiker interface {
 	baseAgent.IAgent[IBaseBiker]
 	// Based on this, the server will call either DecideForce or ChangeBike
-	DecideAction() BikerAction // determines what action the agent is going to take this round. Based on this, the server will call either DecideForce or ChangeBike
-	DecideForce()              // defines the vector you pass to the bike: [pedal, brake, turning]
+	DecideAction() BikerAction       // determines what action the agent is going to take this round. Based on this, the server will call either DecideForce or ChangeBike
+	DecideForce(direction uuid.UUID) // defines the vector you pass to the bike: [pedal, brake, turning]
+	DecideJoining(pendinAgents []uuid.UUID) map[uuid.UUID]bool
+	ChangeBike() uuid.UUID       // called when biker wants to change bike, it will choose which bike to try and join based on agent-specific strategies
+	ProposeDirection() uuid.UUID // returns the id of the desired lootbox based on internal strategy
+	FinalDirectionVote(proposals []uuid.UUID) map[uuid.UUID]float64
+
 	GetForces() utils.Forces
-	ChangeBike() uuid.UUID                 // called when biker wants to change bike, it will choose which bike to try and join based on agent-specific strategies
-	SetBike(uuid.UUID)                     // tells the biker which bike it is on
+	GetColour() utils.Colour        // returns the colour of the lootbox that the agent is currently seeking
+	GetLocation() utils.Coordinates // gets the agent's location
+	GetBike() uuid.UUID             // tells the biker which bike it is on
+	GetEnergyLevel() float64        // returns the energy level of the agent
+	GetResourceAllocationParams() ResourceAllocationParams
+	GetBikeStatus() bool
+
+	SetBike(uuid.UUID)
+	SetAllocationParameters()
+
 	UpdateColour(totColours utils.Colour)  // called if a box of the desired colour has been looted
 	UpdatePoints(pointGained int)          // called by server
-	GetEnergyLevel() float64               // returns the energy level of the agent
 	UpdateEnergyLevel(energyLevel float64) // increase the energy level of the agent by the allocated lootbox share or decrease by expended energy
-	GetResourceAllocationParams() ResourceAllocationParams
-	SetAllocationParameters()
-	GetColour() utils.Colour              // returns the colour of the lootbox that the agent is currently seeking
-	GetLocation() utils.Coordinates       // gets the agent's location
-	UpdateGameState(gameState IGameState) // sets the gameState field at the beginning of each round
+	UpdateGameState(gameState IGameState)  // sets the gameState field at the beginning of each round
+	ToggleOnBike()
 }
 
 type BikerAction int
@@ -101,20 +110,20 @@ func (bb *BaseBiker) GetLocation() utils.Coordinates {
 // returns the nearest lootbox with respect to the agent's bike current position
 // in the MVP this is used to determine the pedalling forces as all agent will be
 // aiming to get to the closest lootbox by default
-func (bb *BaseBiker) NearestLoot() utils.Coordinates {
+func (bb *BaseBiker) NearestLoot() uuid.UUID {
 	currLocation := bb.GetLocation()
 	shortestDist := math.MaxFloat64
-	var nearestDest utils.Coordinates
+	var nearestBox uuid.UUID
 	var currDist float64
 	for _, loot := range bb.gameState.GetLootBoxes() {
 		x, y := loot.GetPosition().X, loot.GetPosition().Y
 		currDist = math.Sqrt(math.Pow(currLocation.X-x, 2) + math.Pow(currLocation.Y-y, 2))
 		if currDist < shortestDist {
-			nearestDest = loot.GetPosition()
+			nearestBox = loot.GetID()
 			shortestDist = currDist
 		}
 	}
-	return nearestDest
+	return nearestBox
 }
 
 // in the MVP the biker's action defaults to pedaling (as it won't be able to change bikes)
@@ -127,13 +136,16 @@ func (bb *BaseBiker) DecideAction() BikerAction {
 // determine the forces (pedalling, breaking and turning)
 // in the MVP the pedalling force will be 1, the breaking 0 and the tunring is determined by the
 // location of the nearest lootbox
-func (bb *BaseBiker) DecideForce() {
+
+// the function is passed in the id of the voted lootbox, for now ignored
+func (bb *BaseBiker) DecideForce(direction uuid.UUID) {
 
 	// NEAREST BOX STRATEGY (MVP)
 	currLocation := bb.GetLocation()
 	nearestLoot := bb.NearestLoot()
-	deltaX := nearestLoot.X - currLocation.X
-	deltaY := nearestLoot.Y - currLocation.Y
+	nearestLootPos := bb.gameState.GetLootBoxes()[nearestLoot].GetPosition()
+	deltaX := nearestLootPos.X - currLocation.X
+	deltaY := nearestLootPos.Y - currLocation.Y
 	angle := math.Atan2(deltaX, deltaY)
 	angleInDegrees := angle * math.Pi / 180
 
@@ -153,6 +165,10 @@ func (bb *BaseBiker) ChangeBike() uuid.UUID {
 
 func (bb *BaseBiker) SetBike(bikeId uuid.UUID) {
 	bb.megaBikeId = bikeId
+}
+
+func (bb *BaseBiker) GetBike() uuid.UUID {
+	return bb.megaBikeId
 }
 
 // this is called when a lootbox of the desidered colour has been looted in order to update the sought colour
@@ -179,6 +195,40 @@ func (bb *BaseBiker) UpdateGameState(gameState IGameState) {
 
 func (bb *BaseBiker) GetResourceAllocationParams() ResourceAllocationParams {
 	return bb.allocationParams
+}
+
+// default implementation returns the id of the nearest lootbox
+func (bb *BaseBiker) ProposeDirection() uuid.UUID {
+	return bb.NearestLoot()
+}
+
+func (bb *BaseBiker) ToggleOnBike() {
+	bb.onBike = !bb.onBike
+}
+
+func (bb *BaseBiker) GetBikeStatus() bool {
+	return bb.onBike
+}
+
+// an agent will have to rank the agents that are trying to join and that they will try to
+func (bb *BaseBiker) DecideJoining(pendingAgents []uuid.UUID) map[uuid.UUID]bool {
+	decision := make(map[uuid.UUID]bool)
+	for _, agent := range pendingAgents {
+		decision[agent] = true
+	}
+	return decision
+}
+
+// this function will contain the agent's strategy on deciding which direction to go to
+// the default implementation returns an equal distribution over all options
+// this will also be tried as returning a rank of options
+func (bb *BaseBiker) FinalDirectionVote(proposals []uuid.UUID) map[uuid.UUID]float64 {
+	votes := make(map[uuid.UUID]float64)
+	totOptions := len(proposals)
+	for _, proposal := range proposals {
+		votes[proposal] = 1.0 / float64(totOptions)
+	}
+	return votes
 }
 
 // this function is going to be called by the server to instantiate bikers in the MVP

--- a/internal/common/utils/CommonFunctions.go
+++ b/internal/common/utils/CommonFunctions.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"math/rand"
+
+	"github.com/google/uuid"
 )
 
 // GenerateRandomCoordinates creates random X and Y coordinates within the grid boundaries.
@@ -22,4 +24,18 @@ func GenerateRandomColour() Colour {
 
 func GenerateRandomFloat(min float64, max float64) float64 {
 	return min + rand.Float64()*(max-min)
+}
+
+// this function will take in a list of maps from ids to their corresponding vote (yes/ no in the case of acceptance)
+// and retunr a list of ids that can be accepted according to some metric (ie more than half voted yes)
+// ranked according to a metric (ie overall number of yes's)
+func GetAcceptanceRanking([]map[uuid.UUID]bool) []uuid.UUID {
+	// TODO implement
+	return make([]uuid.UUID, 0)
+}
+
+// returns the winner accoring to chosen voting strategy (assumes all the maps contain a voting between 0-1
+// for each option, and that all the votings sum to 1)
+func WinnerFromDist([]map[uuid.UUID]float64) uuid.UUID {
+	panic("not implemented")
 }

--- a/internal/server/GameLoop.go
+++ b/internal/server/GameLoop.go
@@ -27,6 +27,7 @@ func (s *Server) RunGameLoop() {
 
 	// Move the mega bikes
 	for _, bike := range s.GetMegaBikes() {
+
 		// Server requests megabikes to update their force and orientation based on agents pedaling
 		bike.UpdateForce()
 		force := bike.GetForce()
@@ -79,9 +80,15 @@ func (s *Server) LootboxCheckAndDistributions() {
 					// the utility share will simply be 1 / the number of agents on the bike
 					utilityShare := 1.0 / float64(totAgents)
 					lootShare := utilityShare * lootbox.GetTotalResources()
+
 					// Allocate loot based on the calculated utility share
 					fmt.Printf("Agent %s allocated %f loot \n", agent.GetID(), lootShare)
 					agent.UpdateEnergyLevel(lootShare)
+
+					// Allocate points if the box is of the right colour
+					if agent.GetColour() == lootbox.GetColour() {
+						agent.UpdatePoints(1)
+					}
 				}
 			}
 		}

--- a/internal/server/GameState.go
+++ b/internal/server/GameState.go
@@ -2,8 +2,9 @@ package server
 
 import (
 	"SOMAS2023/internal/common/objects"
-	"github.com/google/uuid"
 	"math/rand"
+
+	"github.com/google/uuid"
 )
 
 func (s *Server) GetMegaBikes() map[uuid.UUID]objects.IMegaBike {
@@ -24,6 +25,24 @@ func (s *Server) SetBikerBike(biker objects.IBaseBiker, bikeId uuid.UUID) {
 	s.megaBikes[bikeId].AddAgent(biker)
 	s.megaBikeRiders[biker.GetID()] = bikeId
 	biker.SetBike(bikeId)
+}
+
+// get a map of megaBikeIDs mapping to the ids of all Bikers that are trying to join it
+func (s *Server) GetJoiningRequests() map[uuid.UUID][]uuid.UUID {
+	// iterate over all agents, if their onBike is false add to the map their id in correspondance of that of their desired bike
+	bikeRequests := make(map[uuid.UUID][]uuid.UUID)
+
+	for agentID, agent := range s.GetAgentMap() {
+		if !agent.GetBikeStatus() {
+			bike := agent.GetBike()
+			if ids, ok := bikeRequests[bike]; ok {
+				bikeRequests[bike] = append(ids, agentID)
+			} else {
+				bikeRequests[bike] = []uuid.UUID{agentID}
+			}
+		}
+	}
+	return bikeRequests
 }
 
 // GetRandomBikeId returns the ID of a random bike.


### PR DESCRIPTION
Implemented the infrastructure of voting for a direction as discussed during latest meeting. 
The voting happens in three phases: 
1. each agent proposes a direction 
2. each agent evaluates all the directions proposed by bikers on same bike and returns the distribution of its vote given the proposals
3. a final direction is evaluated based on the arrays of distributions 
4. agents decide their moves knowing the winning direction (they are not explicitly forced to follow it). 

Implemented infrastructure for bike joining process: 
1. If agent choses to leave the bike it's removed from it's current bike before the second round of voting for direction (which depends on how many bikers are on the bike in the round) 
2. at the beginning of next round all bikers on bikes which have one or more requests for joining process them by saying which of the one/ more requests they want to accept 
3. all the responsens are processed and an array containing 0 or more acceptable bikers, ranked according to a metric tbd, is defined 
4. the first 8-n accepted bikers are allowed to join the bike (where n is the number of bikers currently on the bike), the remaining ones will try to join another one in another round