### PR TITLE
feat: voting based resource allocation

### DIFF
--- a/internal/common/objects/BaseBiker.go
+++ b/internal/common/objects/BaseBiker.go
@@ -14,10 +14,11 @@ import (
 // These can change based on how we want the allocation to happend, for now they are taken from
 // the lecture slides, but more/less could be taken into account.
 type ResourceAllocationParams struct {
-	resourceNeed          float64 // 0-1, how much energy the agent needs, could be set to 1 - energyLevel
-	resourceDemand        float64 // 0-1, how much energy the agent wants, might differ from resourceNeed
-	resourceProvision     float64 // 0-1, how much energy the agent has given to reach a goal (could be either the sum of pedaling forces since last lootbox, or the latest pedalling force, or something else
-	resourceAppropriation float64 // 0-1, the proportion of what the server allocates that the agent actually gets, for MVP, set to 1
+	resourceNeed          float64               // 0-1, how much energy the agent needs, could be set to 1 - energyLevel
+	resourceDemand        float64               // 0-1, how much energy the agent wants, might differ from resourceNeed
+	resourceProvision     float64               // 0-1, how much energy the agent has given to reach a goal (could be either the sum of pedaling forces since last lootbox, or the latest pedalling force, or something else
+	resourceAppropriation float64               // 0-1, the proportion of what the server allocates that the agent actually gets, for MVP, set to 1
+	resourceVote          map[uuid.UUID]float64 // 0-1, the proportion of the total resource that the agent wants to allocate to each other agent
 }
 
 // agent with defualt strategy for MVP:
@@ -34,6 +35,8 @@ type IBaseBiker interface {
 	GetEnergyLevel() float64               // returns the energy level of the agent
 	UpdateEnergyLevel(energyLevel float64) // increase the energy level of the agent by the allocated lootbox share or decrease by expended energy
 	GetResourceAllocationParams() ResourceAllocationParams
+	GetResourceVote() map[uuid.UUID]float64
+	UpdateResourceAppropriation(resourceAppropriation float64)
 	SetAllocationParameters()
 	GetColour() utils.Colour              // returns the colour of the lootbox that the agent is currently seeking
 	GetLocation() utils.Coordinates       // gets the agent's location
@@ -179,6 +182,14 @@ func (bb *BaseBiker) UpdateGameState(gameState IGameState) {
 
 func (bb *BaseBiker) GetResourceAllocationParams() ResourceAllocationParams {
 	return bb.allocationParams
+}
+
+func (bb *BaseBiker) GetResourceVote() map[uuid.UUID]float64 {
+	return bb.allocationParams.resourceVote
+}
+
+func (bb *BaseBiker) UpdateResourceAppropriation(resourceAppropriation float64) {
+	bb.allocationParams.resourceAppropriation = resourceAppropriation
 }
 
 // this function is going to be called by the server to instantiate bikers in the MVP

--- a/internal/common/objects/BaseBiker.go
+++ b/internal/common/objects/BaseBiker.go
@@ -189,15 +189,14 @@ func (bb *BaseBiker) GetResourceVote() (map[uuid.UUID]float64, error) {
 	resourceVote := bb.allocationParams.resourceVote
 
 	sum := 0.0
-	invalidVote := false
 	for _, vote := range resourceVote {
 		sum += vote
 		if vote < 0 || vote > 1 {
-			invalidVote = true
+			return resourceVote, errors.New("resource votes are not in the range [0,1].")
 		}
 	}
-	if math.Abs(sum-1.0) > 1e-9 || invalidVote {
-		return resourceVote, errors.New("votes do not add up to one or are not in the range [0,1].")
+	if math.Abs(sum-1.0) > 1e-9 {
+		return resourceVote, errors.New("resource votes do not add up to 1.")
 	}
 	return resourceVote, nil
 }

--- a/internal/server/GameLoop.go
+++ b/internal/server/GameLoop.go
@@ -4,7 +4,6 @@ import (
 	"SOMAS2023/internal/common/objects"
 	"SOMAS2023/internal/common/physics"
 	"fmt"
-	"math"
 
 	"github.com/google/uuid"
 )
@@ -73,35 +72,29 @@ func (s *Server) LootboxCheckAndDistributions() {
 				totAgents := len(agents)
 
 				// Compute resource allocation share.
-				validVotes := totAgents
+				valVotes := totAgents
 				accVotes := make(map[uuid.UUID]float64)
 				for _, agent := range agents {
-					agentVote := agent.GetResourceVote()
-
-					// Check if vote is valid.
-					sum := 0.0
-					for _, vote := range agentVote {
-						sum += vote
-					}
-					if math.Abs(sum-1.0) > 1e-9 {
-						validVotes -= 1
-						fmt.Printf("Agent %s provided an invalid resourceVote\n. It's vote will be discarded.", agent.GetID())
+					agentVote, err := agent.GetResourceVote()
+					if err != nil {
+						valVotes -= 1
+						fmt.Printf("Vote discarded for Agent %s: %s", agent.GetID(), err)
 						continue
 					}
 
 					// Accumulate valid votes.
-					for agentID, vote := range agentVote {
-						if _, exists := accVotes[agentID]; !exists {
-							accVotes[agentID] = 0
+					for agentId, vote := range agentVote {
+						if _, exists := accVotes[agentId]; !exists {
+							accVotes[agentId] = 0
 						}
-						accVotes[agentID] += vote
+						accVotes[agentId] += vote
 					}
 				}
 
 				// Normalize resource allocation share.
 				if totAgents != 0 {
-					for agentID, vote := range accVotes {
-						accVotes[agentID] = vote / float64(validVotes)
+					for agentId, vote := range accVotes {
+						accVotes[agentId] = vote / float64(valVotes)
 					}
 				}
 

--- a/internal/server/GameLoop.go
+++ b/internal/server/GameLoop.go
@@ -106,10 +106,11 @@ func (s *Server) LootboxCheckAndDistributions() {
 				}
 
 				// Distribute loot.
+				lootboxTotalResource := lootbox.GetTotalResources()
 				for _, agent := range agents {
 					lootShare, exists := accVotes[agent.GetID()]
 					if exists {
-						lootShare *= lootbox.GetTotalResources()
+						lootShare *= lootboxTotalResource
 
 						fmt.Printf("Agent %s allocated %f loot \n", agent.GetID(), lootShare)
 						agent.UpdateResourceAppropriation(lootShare)

--- a/internal/server/GameLoop.go
+++ b/internal/server/GameLoop.go
@@ -92,7 +92,7 @@ func (s *Server) LootboxCheckAndDistributions() {
 				}
 
 				// Normalize resource allocation share.
-				if totAgents != 0 {
+				if valVotes != 0 {
 					for agentId, vote := range accVotes {
 						accVotes[agentId] = vote / float64(valVotes)
 					}


### PR DESCRIPTION
- Basic Resource Allocation
     - An agent updates their `ResourceVote` parameter. Values in `ResourceVote` must add to one. If not, it is considered an invalid vote.
     - When a collision is detected, we sum `ResourceVotes` from each agent and normalize it. Invalid votes from agents are not considered. The result will define our loot allocation.

cc: @IshaanReni 