### PR TITLE
small fixes to allow for cumulative loot allocation to happen

### DIFF
--- a/internal/common/utils/CommonParameters.go
+++ b/internal/common/utils/CommonParameters.go
@@ -3,8 +3,8 @@ package utils
 /*
 Environment Parameters
 */
-const GridHeight float64 = 500.0
-const GridWidth float64 = 500.0
+const GridHeight float64 = 75.0
+const GridWidth float64 = 75.0
 const CollisionThreshold float64 = 7.0
 const Epsilon float64 = 0.01 // tolerance for FP rounding and checking if == 1.0
 
@@ -20,7 +20,7 @@ const AudiMaxForce float64 = 1.0  // The audi's force is equivalent to that of o
 
 const DragCoefficient float64 = 1.0 // Drag coefficient can be optimised in experimentation
 
-const MovingDepletion float64 = 1.0 // proportionality of energy loss
+const MovingDepletion float64 = 0.1 // proportionality of energy loss
 
 const LimboEnergyPenalty float64 = -0.25 // amount of energy lost per round when off a bike
 

--- a/internal/common/voting/VotingEngine.go
+++ b/internal/common/voting/VotingEngine.go
@@ -51,7 +51,7 @@ func CumulativeDist(voters []IVoter) (map[uuid.UUID]float64, error) {
 	if len(voters) == 0 {
 		panic("no votes provided")
 	}
-
+	// Vote checks for each voter
 	aggregateVotes := make(map[uuid.UUID]float64)
 	for _, IVoter := range voters {
 		if math.Abs(SumOfValues(IVoter)-1.0) > utils.Epsilon {
@@ -62,8 +62,10 @@ func CumulativeDist(voters []IVoter) (map[uuid.UUID]float64, error) {
 			aggregateVotes[id] += vote
 		}
 	}
-	// TODO normalise
-
+	// normalising step for all voters involved
+	for agentId, vote := range aggregateVotes {
+		aggregateVotes[agentId] = vote / float64(len(voters))
+	}
 	return aggregateVotes, nil
 }
 

--- a/internal/server/Spawner.go
+++ b/internal/server/Spawner.go
@@ -26,7 +26,8 @@ func (s *Server) spawnLootBox() {
 }
 
 func (s *Server) replenishLootBoxes() {
-	for i := 0; i < LootBoxCount-len(s.lootBoxes); i++ {
+	count := LootBoxCount - len(s.lootBoxes)
+	for i := 0; i < count; i++ {
 		s.spawnLootBox()
 	}
 }


### PR DESCRIPTION
small fixes were made so that collisions between no biker megabikes and lootboxes are bypassed, normalisation in the cumulativedist function now works and winningAllocations is no longer always empty