### PR TITLE
Ln/fix kick out

### DIFF
--- a/internal/server/GameState.go
+++ b/internal/server/GameState.go
@@ -3,6 +3,7 @@ package server
 import (
 	"SOMAS2023/internal/common/objects"
 	"math/rand"
+	"slices"
 
 	"github.com/google/uuid"
 )
@@ -20,12 +21,13 @@ func (s *Server) GetAudi() objects.IAudi {
 }
 
 // get a map of megaBikeIDs mapping to the ids of all Bikers that are trying to join it
-func (s *Server) GetJoiningRequests() map[uuid.UUID][]uuid.UUID {
+func (s *Server) GetJoiningRequests(inLimbo []uuid.UUID) map[uuid.UUID][]uuid.UUID {
 	// iterate over all agents, if their onBike is false add to the map their id in correspondance of that of their desired bike
 	bikeRequests := make(map[uuid.UUID][]uuid.UUID)
 
 	for agentID, agent := range s.GetAgentMap() {
-		if !agent.GetBikeStatus() {
+		// don't process joining requests of agents in limbo
+		if !agent.GetBikeStatus() && !slices.Contains(inLimbo, agentID) {
 			bike := agent.GetBike()
 			if ids, ok := bikeRequests[bike]; ok {
 				bikeRequests[bike] = append(ids, agentID)

--- a/internal/server/Server.go
+++ b/internal/server/Server.go
@@ -20,15 +20,15 @@ type IBaseBikerServer interface {
 	GetMegaBikes() map[uuid.UUID]objects.IMegaBike
 	GetLootBoxes() map[uuid.UUID]objects.ILootBox
 	GetAudi() objects.IAudi
-	GetJoiningRequests() map[uuid.UUID][]uuid.UUID
+	GetJoiningRequests([]uuid.UUID) map[uuid.UUID][]uuid.UUID
 	GetRandomBikeId() uuid.UUID
 	RulerElection(agents []objects.IBaseBiker, governance utils.Governance) uuid.UUID
 	RunRulerAction(bike objects.IMegaBike) uuid.UUID
 	RunDemocraticAction(bike objects.IMegaBike, weights map[uuid.UUID]float64) uuid.UUID
 	NewGameStateDump() GameStateDump
-	GetLeavingDecisions(gameState objects.IGameState)
-	HandleKickoutProcess()
-	ProcessJoiningRequests()
+	GetLeavingDecisions(gameState objects.IGameState) []uuid.UUID
+	HandleKickoutProcess() []uuid.UUID
+	ProcessJoiningRequests(inLimbo []uuid.UUID)
 	RunActionProcess()
 	AudiCollisionCheck()
 	AddAgentToBike(agent objects.IBaseBiker)
@@ -56,12 +56,6 @@ func Initialize(iterations int) IBaseBikerServer {
 	}
 	server.replenishLootBoxes()
 	server.replenishMegaBikes()
-
-	// Randomly allocate bikers to bikes
-	for _, biker := range server.GetAgentMap() {
-		biker.SetBike(server.GetRandomBikeId())
-		server.AddAgentToBike(biker)
-	}
 
 	return server
 }

--- a/internal/server/SimLoop.go
+++ b/internal/server/SimLoop.go
@@ -115,7 +115,8 @@ func (s *Server) FoundingInstitutions() {
 			chosenBike := bikesAvailable[0]
 			// add agent to bike
 			agentInt := s.GetAgentMap()[agent]
-			s.GetMegaBikes()[chosenBike].AddAgent(agentInt)
+			agentInt.SetBike(chosenBike)
+			s.AddAgentToBike(agentInt)
 		}
 	}
 

--- a/internal/server/tests/game_loop_test.go
+++ b/internal/server/tests/game_loop_test.go
@@ -101,7 +101,7 @@ func TestProcessJoiningRequests(t *testing.T) {
 	// check that all of them are now on bikes
 	// check that there are no bikers left with on bike = false
 
-	s.ProcessJoiningRequests()
+	s.ProcessJoiningRequests(make([]uuid.UUID, 0))
 	for bikeID, agents := range requests {
 		bike := s.GetMegaBikes()[bikeID]
 		for _, agent := range agents {

--- a/internal/server/tests/game_state_test.go
+++ b/internal/server/tests/game_state_test.go
@@ -45,7 +45,7 @@ func TestGetJoiningRequests(t *testing.T) {
 	}
 
 	// 3. check that joining requests reflect the previous actions
-	bikeRequests := s.GetJoiningRequests()
+	bikeRequests := s.GetJoiningRequests(make([]uuid.UUID, 0))
 	if len(bikeRequests) != len(requests) {
 		t.Error("bike requests processed incorrectly: empty")
 	}

--- a/internal/server/tests/governance_test.go
+++ b/internal/server/tests/governance_test.go
@@ -69,7 +69,7 @@ func TestRunRulerActionDictator(t *testing.T) {
 			// make them vote for the dictator (assume that function works properly)
 			// get the dictator id (or check what it should be given the MVP strategy, this must be deterministic though)
 			ruler := s.RulerElection(agents, utils.Dictatorship)
-			direction := s.RunRulerAction(bike, utils.Dictatorship)
+			direction := s.RunRulerAction(bike)
 			// set the force of the dictator
 			// check that the function works for it
 
@@ -103,7 +103,7 @@ func TestRunRulerActionLeader(t *testing.T) {
 			// make them vote for the dictator (assume that function works properly)
 			// get the dictator id (or check what it should be given the MVP strategy, this must be deterministic though)
 			ruler := s.RulerElection(agents, utils.Leadership)
-			direction := s.RunRulerAction(bike, utils.Leadership)
+			direction := s.RunRulerAction(bike)
 			// set the force of the dictator
 			// check that the function works for it
 
@@ -134,7 +134,11 @@ func TestRunDemocratingAction(t *testing.T) {
 		agents := bike.GetAgents()
 		if len(agents) != 0 {
 
-			direction := s.RunDemocraticAction(bike)
+			weights := make(map[uuid.UUID]float64)
+			for _, agent := range agents {
+				weights[agent.GetID()] = 1.0
+			}
+			direction := s.RunDemocraticAction(bike, weights)
 
 			_, exists := s.GetLootBoxes()[direction]
 			if !exists {


### PR DESCRIPTION
- the bikers were still allocated to random bikes (which caused inconsistencies between the bike maps and the agent's bike id) 
- the joingin requests of leaving/ kicked off agents were handled immediately, now they are handled at the beginnign of next turn (limbo) 
