### PR TITLE
team 2: fix leader weights that sum to 0.

### DIFF
--- a/internal/clients/team2/agent/actions.go
+++ b/internal/clients/team2/agent/actions.go
@@ -64,7 +64,7 @@ func (a *AgentTwo) DecideWeights(action utils.Action) map[uuid.UUID]float64 {
 	weights := make(map[uuid.UUID]float64)
 	agents := a.GetFellowBikers()
 	for _, agent := range agents {
-		if agent.GetEnergyLevel() <= 0 || !agent.GetBikeStatus() {
+		if !agent.GetBikeStatus() {
 			fmt.Println("Agent is dead or is not on a bike")
 			continue
 		}
@@ -139,15 +139,19 @@ func (a *AgentTwo) DecideAllocation() voting.IdVoteMap {
 				continue
 			}
 		}
-		if math.IsNaN(socialCapital[id]) {
-			runtime.Breakpoint()
-			panic("dhsd")
-		}
 		// This agent is not a fellow biker - remove it from SC
 		delete(socialCapital, id)
 	}
 	// We give ourselves 1.0
 	socialCapital[a.GetID()] = 1.0
+
+	sum := 0.0
+	for _, v := range socialCapital {
+		sum += v
+	}
+	if sum == 0 {
+		fmt.Print("Sum is 0")
+	}
 	return socialCapital
 }
 

--- a/internal/clients/team2/agent/actions.go
+++ b/internal/clients/team2/agent/actions.go
@@ -144,14 +144,6 @@ func (a *AgentTwo) DecideAllocation() voting.IdVoteMap {
 	}
 	// We give ourselves 1.0
 	socialCapital[a.GetID()] = 1.0
-
-	sum := 0.0
-	for _, v := range socialCapital {
-		sum += v
-	}
-	if sum == 0 {
-		fmt.Print("Sum is 0")
-	}
 	return socialCapital
 }
 

--- a/internal/clients/team2/modules/SocialCapitalParameters.go
+++ b/internal/clients/team2/modules/SocialCapitalParameters.go
@@ -3,7 +3,7 @@ package modules
 // Constants related to the calculation of social capital
 const (
 	ReputationWeight  = 1.0 // Weight for trust in social capital calculation
-	InstitutionWeight = 0.0 // Weight for institution affiliation in social capital calculation
+	InstitutionWeight = 1.0 // Weight for institution affiliation in social capital calculation
 	NetworkWeight     = 1.0 // Weight for network strength in social capital calculation
 )
 
@@ -15,13 +15,13 @@ const (
 
 // Constants related to the calculation of Institution
 const (
-	InstitutionEventWeight_Adhereance = 0.0  // Weight for rule adhereance in institution calculation
-	InstitutionEventWeight_Voting     = 0.0  // Weight for voting in institution calculation
-	InstitutionEventWeight_KickedOut  = 0.0  // Weight for being kicked out of bike in institution calculation
-	InstitutionEventWeight_Accepted   = 0.0  // Weight for being accepted to bike in institution calculation
-	InstitutionEventWeight_VotedRole  = 0.0  // Weight for role assignment in institution calculation
-	InstitutionKickoffEventValue      = -0.5 // Value for being kicked out of bike in institution calculation
-	InstitutionAcceptedEventValue     = 0.2  // Value for being accepted to bike in institution calculation
+	InstitutionEventWeight_Adhereance = 0.3   // Weight for rule adhereance in institution calculation
+	InstitutionEventWeight_Voting     = 0.1   // Weight for voting in institution calculation
+	InstitutionEventWeight_KickedOut  = 0.1   // Weight for being kicked out of bike in institution calculation
+	InstitutionEventWeight_Accepted   = 0.1   // Weight for being accepted to bike in institution calculation
+	InstitutionEventWeight_VotedRole  = 0.1   // Weight for role assignment in institution calculation
+	InstitutionKickoffEventValue      = -0.05 // Value for being kicked out of bike in institution calculation
+	InstitutionAcceptedEventValue     = 0.2   // Value for being accepted to bike in institution calculation)
 )
 
 const (


### PR DESCRIPTION
- Agents on a bike may have negative energy before the server declares them dead.
- DecideWeights skips dead agents - agents with an energy level less than 0.
- We remove this condition as an agent with an energy level of less than 0 is alive before the server kills them.