### PR TITLE
[experiments] team 2: fix nil lootbox

### DIFF
--- a/internal/clients/team2/modules/Environment.go
+++ b/internal/clients/team2/modules/Environment.go
@@ -68,7 +68,7 @@ func (e *EnvironmentModule) GetNearestLootbox(agentId uuid.UUID) uuid.UUID {
 }
 
 func (e *EnvironmentModule) GetNearestLootboxByColor(agentId uuid.UUID, color utils.Colour) uuid.UUID {
-	nearestLootbox := uuid.Nil
+	nearestLootbox := e.GetNearestLootbox(agentId) // Defaults to nearest lootbox
 	minDist := math.MaxFloat64
 	for _, lootbox := range e.GetLootBoxesByColor(color) {
 		dist := e.GetDistanceToLootbox(lootbox.GetID())


### PR DESCRIPTION
- The nearest loot box by color could return nil.
- Adds a default.